### PR TITLE
Bug fix: Debounce drag-and-drop events to avoid excess POST requests

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -67,6 +67,15 @@ document.addEventListener('DOMContentLoaded', () => {
     // State
     let todos = {};
     let currentList = 'List 1';
+    let saveTimeout;
+
+    // Drag-and-drop debouncer
+    function queueSaveTodos() {
+        clearTimeout(saveTimeout);
+        saveTimeout = setTimeout(() => {
+            saveTodos();
+        }, 300);
+    }
 
     // List Management
     function initializeLists(data) {
@@ -438,7 +447,7 @@ document.addEventListener('DOMContentLoaded', () => {
                             return activeTodos.find(t => t.text === item.getAttribute('data-todo-id'));
                         });
                         todos[currentList] = [...newOrder, ...completedTodos];
-                        saveTodos();
+                        queueSaveTodos();
                     }
                 }
             });


### PR DESCRIPTION
Issue: Drag-and-dropping a list's item fires hundreds of POST requests to save the new order.

<img width="1375" height="719" alt="image" src="https://github.com/user-attachments/assets/16dccbca-e4f1-49b9-9d8c-69dde48c216e" />

Fix: Add a delay when saving the new order.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a debouncer to prevent excessive POST requests when drag-and-dropping todo list items. Previously, dragging items triggered hundreds of save requests; now a 300ms delay ensures the order is only saved once after the user finishes dragging.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `public/app.js` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag-and-drop reordering so changes are saved less aggressively while moving items.
  * Reduced repeated save activity during item dragging, which should make reordering feel smoother and more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->